### PR TITLE
Refactor the matching logic between pronunciation and meter out of the HTML methods

### DIFF
--- a/Metroscope.py
+++ b/Metroscope.py
@@ -125,10 +125,11 @@ class WordBuilder(object):
         closing_tag = "</" + tag + ">"
         return opening_tag + snippet + closing_tag
 
-    def matched_syllables(self, pattern):
+    def _matched_syllables(self, pattern):
         """
         Match the pronounced stresses against the given pattern.
 
+        Private method in service of stressed_HTML().
         Returns a list of lists:
             - syllable string,
             - Boolean for pattern stress,
@@ -155,42 +156,21 @@ class WordBuilder(object):
         """
         Mark up the original word based on the stress pattern provided.
 
-        Return the word with the syllables wrapped with HTML tags based on
-        their stress in the pattern, with a style attribute based on whether
-        it aligns with the expected meter.
+        Return the word with the syllables wrapped with HTML tags and style
+        attributes based on stress, provided meter, and whether they match.
         Finally, wrap a <span> tag around the entire word.
         """
-        MATCH = "color:black"
-        NOT_MATCH = "color:red"
-        STRESSED = "strong"
-        UNSTRESSED = "span"
-        UNKNOWN = "small"
+        STYLES = {True: "color:black",
+                  False: "color:red"}
+        TAGS = {True: "strong",
+                False: "span",
+                None: "small"}
 
         result = ""
-        for syllable, pronunciation_stress in self.stressed_syllables:
-            if pattern:
-                if pattern.pop(0):
-                    if pronunciation_stress == '0':
-                        result += self.tag_string(syllable,
-                                                  STRESSED,
-                                                  NOT_MATCH)
-                    else:
-                        result += self.tag_string(syllable,
-                                                  STRESSED,
-                                                  MATCH)
-                else:
-                    if pronunciation_stress == '2':
-                        result += self.tag_string(syllable,
-                                                  UNSTRESSED,
-                                                  NOT_MATCH)
-                    else:
-                        result += self.tag_string(syllable,
-                                                  UNSTRESSED,
-                                                  MATCH)
-            else:
-                result += self.tag_string(syllable,
-                                          UNKNOWN,
-                                          NOT_MATCH)
+        for syllable, stress, match in self._matched_syllables(pattern):
+            result += self.tag_string(syllable,
+                                      TAGS[stress],
+                                      STYLES[match])
         return self.tag_string(result, "span")
 
 

--- a/Metroscope.py
+++ b/Metroscope.py
@@ -125,7 +125,7 @@ class WordBuilder(object):
         closing_tag = "</" + tag + ">"
         return opening_tag + snippet + closing_tag
 
-    def stressed_HTML(self, stresses):
+    def stressed_HTML(self, pattern):
         """
         Mark up the original word based on the stress pattern provided.
 
@@ -142,8 +142,8 @@ class WordBuilder(object):
 
         result = ""
         for syllable, pronunciation_stress in self.stressed_syllables:
-            if stresses:
-                if stresses.pop(0):
+            if pattern:
+                if pattern.pop(0):
                     if pronunciation_stress == '0':
                         result += self.tag_string(syllable,
                                                   STRESSED,

--- a/Metroscope.py
+++ b/Metroscope.py
@@ -125,6 +125,32 @@ class WordBuilder(object):
         closing_tag = "</" + tag + ">"
         return opening_tag + snippet + closing_tag
 
+    def matched_syllables(self, pattern):
+        """
+        Match the pronounced stresses against the given pattern.
+
+        Returns a list of lists:
+            - syllable string,
+            - Boolean for pattern stress,
+            - Boolean for match between pattern & pronunciation
+        """
+        result = []
+        for syllable, pronunciation_stress in self.stressed_syllables:
+            if pattern:
+                if pattern.pop(0):
+                    result.append([syllable,
+                                   True,
+                                   pronunciation_stress != '0'])
+                else:
+                    result.append([syllable,
+                                   False,
+                                   pronunciation_stress != '2'])
+            else:
+                result.append([syllable,
+                               None,
+                               False])
+        return result
+
     def stressed_HTML(self, pattern):
         """
         Mark up the original word based on the stress pattern provided.

--- a/test_Metroscope.py
+++ b/test_Metroscope.py
@@ -176,6 +176,26 @@ class Test_WordBuilder(unittest.TestCase):
             self.assertEqual(wb.tag_string("text", "strong", "color:red"),
                              "<strong style='color:red'>text</strong>")
 
+    def test_matched_syllables(self):
+        """Should give a list of list with the word's fit to meter."""
+        WORDS = {
+                 "automatic":
+                 [['au', False, False],
+                  ['to', True, False],
+                  ['ma', False, True],
+                  ['tic', None, False]],
+                 "Shadows":
+                 [['Sha', False, True],
+                  ['dows', True, True]],
+                 "One":
+                 [['One', False, True]],
+                 }
+        for word, matches in WORDS.items():
+            with self.subTest('Original word: ' + word):
+                METER = [0, 1, 0]
+                self.assertEqual(WordBuilder(word).matched_syllables(METER),
+                                 matches)
+
     def test_stressed_HTML(self):
         """Should give an HTML representation of the word's fit to meter."""
         WORDS = {

--- a/test_Metroscope.py
+++ b/test_Metroscope.py
@@ -176,7 +176,7 @@ class Test_WordBuilder(unittest.TestCase):
             self.assertEqual(wb.tag_string("text", "strong", "color:red"),
                              "<strong style='color:red'>text</strong>")
 
-    def test_matched_syllables(self):
+    def test__matched_syllables(self):
         """Should give a list of list with the word's fit to meter."""
         WORDS = {
                  "automatic":
@@ -193,7 +193,7 @@ class Test_WordBuilder(unittest.TestCase):
         for word, matches in WORDS.items():
             with self.subTest('Original word: ' + word):
                 METER = [0, 1, 0]
-                self.assertEqual(WordBuilder(word).matched_syllables(METER),
+                self.assertEqual(WordBuilder(word)._matched_syllables(METER),
                                  matches)
 
     def test_stressed_HTML(self):


### PR DESCRIPTION
Last bit of refactoring I think I need before being able to start working on new features.

With this change, the comparison between the word pronunciation stresses and the meter pattern is done separately, and those results are used to generate the HTML.

Both unit tests and smoke testing on localhost seem to run significantly faster, so that's a good outcome.