### PR TITLE
Use the --deploy option on pipenv install. This closes #59.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.7"
 install:
   - pip install pipenv
-  - pipenv install
+  - pipenv install --deploy
 # automatic tests
 script:
   - flake8


### PR DESCRIPTION
Should catch any mistmatch between pipfile and pipfile.loc, failing any builds in TravisCI.