### PR TITLE
Refactored poems from db and enable review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,21 @@
+{
+  "name": "Metroscope",
+  "scripts": {},
+  "env": {
+    "FLASK_APP": {
+      "required": true
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [],
+  "buildpacks": [
+    {
+      "url": "heroku/python"
+    }
+  ],
+  "stack": "heroku-18"
+}

--- a/metroscope/scanned_poem.py
+++ b/metroscope/scanned_poem.py
@@ -78,6 +78,10 @@ def scanned_poem(poem, meter):
     Wrap the poem in a <div> tag, each stanza in a <p> tag,
     and end each line with a <br> tag.
     """
+    meter_pattern = []
+    for beat in meter:
+        meter_pattern.append(beat == '1')
+
     lines = []
     for line in poem.split("\n"):
         if line != "":
@@ -93,7 +97,7 @@ def scanned_poem(poem, meter):
             rhymes = {"None": "_"}
         else:
             result += "<td>"
-            result += line.stressed_HTML(meter)
+            result += line.stressed_HTML(meter_pattern)
             rp = str(line._rhyming_part)
             result += "</td>\n<td data-toggle='tooltip' title='"
             result += rp + "'>"

--- a/run.py
+++ b/run.py
@@ -100,23 +100,15 @@ def poem(keyword):
     if "poems" not in db.engine.table_names():
         reset_db()
     poem = Poem.query.filter_by(keyword=keyword).first_or_404()
-    POEM_TITLE = poem.title
-    POET_NAME = poem.author.name
-    POEM_TEXT = poem.raw_text
-    METER_NAME = poem.meter.name
     METER_PATTERN = []
     for beat in poem.meter.pattern:
-        if beat == '0':
-            METER_PATTERN.append(0)
-        elif beat == '1':
-            METER_PATTERN.append(1)
-    print(METER_PATTERN)
-    #    return render_template('404.html'), 404
+        METER_PATTERN.append(beat == '1')
+
     return render_template("poem.html",
-                           title=POEM_TITLE,
-                           poet=POET_NAME,
-                           meter=METER_NAME,
-                           poem=scanned_poem(POEM_TEXT, METER_PATTERN),
+                           title=poem.title,
+                           poet=poem.author.name,
+                           meter=poem.meter.name,
+                           poem=scanned_poem(poem.raw_text, METER_PATTERN),
                            )
 
 

--- a/run.py
+++ b/run.py
@@ -98,7 +98,8 @@ def about():
 def poem(keyword):
     """Define the poem route."""
     if "poems" not in db.engine.table_names():
-        reset_db()
+        return render_template('404.html'), 404
+
     poem = Poem.query.filter_by(keyword=keyword).first_or_404()
     METER_PATTERN = []
     for beat in poem.meter.pattern:

--- a/run.py
+++ b/run.py
@@ -2,6 +2,7 @@
 
 import os
 from flask import Flask, render_template
+import click
 from flask_bootstrap import Bootstrap
 from flask_sqlalchemy import SQLAlchemy
 from metroscope import scanned_poem
@@ -131,23 +132,30 @@ def internal_server_error(e):
     return render_template('500.html'), 500
 
 
+@application.cli.command('reset_db')
 def reset_db():
     """Reset the database with the sample poems."""
+    click.echo("Dropping all tables...")
     db.drop_all()
+    click.echo("Creating all tables...")
     db.create_all()
 
+    click.echo("Adding meters...")
     db.session.add(Meter(name='Iambic Pentameter',
                          pattern='0101010101'))
     db.session.add(Meter(name='Cataleptic Anapestic Trimeter',
                          pattern='01001001'))
 
+    click.echo("Adding poets...")
     db.session.add(Poet(name='John Keats'))
     db.session.add(Poet(name='Edward Lear'))
     db.session.add(Poet(name='John Donne'))
     db.session.add(Poet(name='Wilfred Owen'))
 
+    click.echo("Commiting to database...")
     db.session.commit()
 
+    click.echo("Adding poems...")
     with open('Texts/FreeTexts/OdeOnIndolence.txt', "r") as poem:
         db.session.add(Poem(title='Ode on Indolence',
                             keyword='OdeOnIndolence',
@@ -173,7 +181,10 @@ def reset_db():
                             poet_id=4,
                             meter_id=1))
 
+    click.echo("Commiting to database...")
     db.session.commit()
+
+    click.echo("Database reset!")
 
 
 if __name__ == "__main__":

--- a/run.py
+++ b/run.py
@@ -78,7 +78,11 @@ def make_shell_context():
 @application.route("/")
 def home():
     """Define the home route."""
-    return render_template("home.html")
+    if "poems" not in db.engine.table_names():
+        poems = []
+    else:
+        poems = Poem.query.all()
+    return render_template("home.html", poems=poems)
 
 
 @application.route("/about")

--- a/run.py
+++ b/run.py
@@ -97,20 +97,19 @@ def about():
 @application.route("/poem/<keyword>")
 def poem(keyword):
     """Define the poem route."""
+    # if the poems table does not exist, 404 the route
     if "poems" not in db.engine.table_names():
         return render_template('404.html'), 404
 
+    # retrieve the requested poem if it exists
     poem = Poem.query.filter_by(keyword=keyword).first_or_404()
-    METER_PATTERN = []
-    for beat in poem.meter.pattern:
-        METER_PATTERN.append(beat == '1')
 
     return render_template("poem.html",
                            title=poem.title,
                            poet=poem.author.name,
                            meter=poem.meter.name,
-                           poem=scanned_poem(poem.raw_text, METER_PATTERN),
-                           )
+                           poem=scanned_poem(poem.raw_text,
+                                             poem.meter.pattern))
 
 
 @application.errorhandler(404)

--- a/templates/home.html
+++ b/templates/home.html
@@ -7,8 +7,11 @@
 {% block page_content %}
     <h1>Metroscope</h1>
     <p>Choose a poem from the list below:</p>
-    <li><a href="{{ url_for('poem', keyword='OdeOnIndolence') }}">Ode on Indolence</a></li>
-    <li><a href="{{ url_for('poem', keyword='OldManWithBeard') }}">There Was an Old Man with a Beard</a></li>
-    <li><a href="{{ url_for('poem', keyword='Flea') }}">The Flea</a></li>
-    <li><a href="{{ url_for('poem', keyword='AnthemForDoomedYouth') }}">Anthem for Doomed Youth</a></li>
+    {% if poems == [] %}
+        <li>Sorry, no poems in the database!</li>
+    {% else %}
+        {% for poem in poems %}
+            <li><a href="{{ url_for('poem', keyword=poem.keyword) }}">{{poem.title}}</a></li>
+        {% endfor %}
+    {% endif %}
 {% endblock page_content %}

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -10,9 +10,11 @@ def client():
     yield application.test_client()
 
 
-@pytest.mark.parametrize("route", ['/', '/about', '/poem/OldManWithBeard'])
+@pytest.mark.parametrize("route", ['/', '/about'])
 def test_200(client, route):
     """Make sure the page returns a 200."""
+    # currently does not test the poem/foo route when poem foo exists
+    # need to put that back in once there's a test database
     assert "200" in client.get(route).status
 
 


### PR DESCRIPTION
The routes retrieve the poems from the db, and fall back gracefully if the poems table does not exist or is empty. `home/` closes #85 and `poem/<keyword>` closes #86.
Therefore, `reset_db()` is not called when the table is empty, and it is now invoked from the command line as `flask reset_db` closes #87.
Lastly, to compensate for those nasty deployments failures, added an `app.json` file to support review apps in Heroku, which closes #91.